### PR TITLE
Add `include` Cargo.toml include section to avoid publishing huge crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "Type with your on handwritten letter."
 repository = "https://github.com/gabrielcarneiro97/handmade"
 readme = "README.md"
+include = ["src/**/*", "LICENSE", "README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]


### PR DESCRIPTION
This might exclude files that are supposed to be inside of the crate,
so this PR should be seen as nothing more than the beginning of a
conversation to see if the crate size can be reduced.

Please let me know if some files are needed and I am happy
to adjust the PR accordingly.

Thank a bunch
